### PR TITLE
[feat]: custom snnTorch LIF for moving average tracking

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 jobs:
-  pep8:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -50,6 +50,10 @@ class TemporalFilter:
         from reacting too strongly to what might be noise. Conversely, for a
         system with slow-moving dynamics, you might choose larger values for
         both tau_rise and tau_fall to avoid reacting to insignificant changes.
+
+        Zenke's paper uses:
+         * alpha: tau_rise of 2ms and a tau_fall of 10ms
+         * beta: tau_rise of 5ms and a tau_fall of 20ms
         """
         self.rise: Optional[torch.Tensor] = None
         self.fall: Optional[torch.Tensor] = None
@@ -76,7 +80,7 @@ class TemporalFilter:
 
 class SpikeMovingAverage:
 
-    def __init__(self, tau_mean: float) -> None:
+    def __init__(self, tau_mean: float = 600) -> None:
         """
         tau_mean:
          * A time constant that determines the smoothing factor for the moving average
@@ -84,6 +88,8 @@ class SpikeMovingAverage:
          * A smaller tau_mean will make the average more sensitive to recent spikes.
          * A larger tau_mean will give a smoother average that is less responsive to
            individual spikes, reflecting a longer-term average rate.
+
+        Zenke's paper uses a tau_mean of 600s
         """
         self.mean: Optional[torch.Tensor] = None
         self.tau_mean = tau_mean
@@ -106,7 +112,7 @@ class SpikeMovingAverage:
 
 class VarianceMovingAverage:
 
-    def __init__(self, tau_var: float) -> None:
+    def __init__(self, tau_var: float = .02) -> None:
         """
         tau_var:
          * A time constant that sets the smoothing factor for the moving average
@@ -114,6 +120,8 @@ class VarianceMovingAverage:
          * A smaller tau_var makes the variance more sensitive to recent fluctuations.
          * A larger tau_var results in a smoother variance calculation, less affected
            by short-term changes and more reflective of long-term variability.
+
+        Zenke's paper uses a tau_var of 20ms
         """
         self.variance: Optional[torch.Tensor] = None
         self.tau_var: float = tau_var

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -54,6 +54,9 @@ class TemporalFilter:
         Zenke's paper uses:
          * alpha: tau_rise of 2ms and a tau_fall of 10ms
          * beta: tau_rise of 5ms and a tau_fall of 20ms
+
+         TODO: Concern here is that we are initializing the rise and fall states
+                with zeros, which might not be the best approach.
         """
         self.rise: Optional[torch.Tensor] = None
         self.fall: Optional[torch.Tensor] = None
@@ -89,7 +92,10 @@ class SpikeMovingAverage:
          * A larger tau_mean will give a smoother average that is less responsive to
            individual spikes, reflecting a longer-term average rate.
 
-        Zenke's paper uses a tau_mean of 600s
+        Zenke's paper uses a tau_mean of 600s.
+
+        TODO: Concern here is that we are initializing the mean state with zeros,
+                which might not be the best approach.
         """
         self.mean: Optional[torch.Tensor] = None
         self.tau_mean = tau_mean
@@ -121,7 +127,10 @@ class VarianceMovingAverage:
          * A larger tau_var results in a smoother variance calculation, less affected
            by short-term changes and more reflective of long-term variability.
 
-        Zenke's paper uses a tau_var of 20ms
+        Zenke's paper uses a tau_var of 20ms.
+
+        TODO: Concern here is that we are initializing the variance state with zeros,
+                which might not be the best approach.
         """
         self.variance: Optional[torch.Tensor] = None
         self.tau_var: float = tau_var

--- a/model/tests/test_util.py
+++ b/model/tests/test_util.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 from model.src.util import SpikeMovingAverage, TemporalFilter, VarianceMovingAverage
 
@@ -7,26 +8,28 @@ def test_temporal_filter() -> None:
     tf = TemporalFilter(tau_rise=1, tau_fall=1)
 
     # Initial apply since temporal filter is second order
-    tf.apply(error=1)
+    tf.apply(value=torch.Tensor([1]))
 
     # Apply a single error with a small dt should result in small change
-    assert tf.apply(error=1) == pytest.approx(1.7357588823428847)
+    assert tf.apply(value=torch.Tensor([1])).item(
+    ) == pytest.approx(1.7357588823428847)
 
     # Apply a zero error should result in decay of the state
-    assert tf.apply(error=0) == pytest.approx(1.1417647320527227)
+    assert tf.apply(value=torch.Tensor([0])).item(
+    ) == pytest.approx(1.1417647320527227)
 
 
 def test_spike_moving_average() -> None:
     sma = SpikeMovingAverage(tau_mean=1)
 
     # Apply a single spike
-    assert sma.apply(spike=1) == 1.0
+    assert sma.apply(spike=torch.Tensor([1])).item() == 1.0
 
     # Apply another spike, the average should increase
-    assert sma.apply(spike=2) == 2.0
+    assert sma.apply(spike=torch.Tensor([2])).item() == 2.0
 
     # After some time with no spikes, the average should decay
-    assert sma.apply(spike=0) == 0.0
+    assert sma.apply(spike=torch.Tensor([0])).item() == 0.0
 
 
 def test_variance_moving_average() -> None:
@@ -36,27 +39,27 @@ def test_variance_moving_average() -> None:
     vma = VarianceMovingAverage(tau_var)
 
     # Apply spikes to the moving average
-    spike = 2
+    spike = torch.Tensor([2])
     for _ in range(20):
         # NOTE: The spike moving average is always updated first
         sma.apply(spike=spike)
         vma.apply(spike=spike, spike_moving_average=sma.tracked_value())
-    assert sma.tracked_value() > 1
+    assert sma.tracked_value().item() > 1
 
     sma_value = sma.apply(spike=spike)
     expected_variance = 0.3508073062162211
     assert vma.apply(
-        spike=spike, spike_moving_average=sma_value) == pytest.approx(expected_variance)
+        spike=spike, spike_moving_average=sma_value).item() == pytest.approx(expected_variance)
 
     # After some time with no spikes, the variance should increase
-    spike_2 = 0
+    spike_2 = torch.Tensor([0])
     sma_value = sma.apply(spike=spike_2)  # Mean should decay
     assert vma.apply(
-        spike=spike_2, spike_moving_average=sma_value) > expected_variance
+        spike=spike_2, spike_moving_average=sma_value).item() > expected_variance
 
     # Apply another spike, the variance should adjust based on the new mean
-    spike_3 = 5
+    spike_3 = torch.Tensor([5])
     sma_value = sma.apply(spike=spike_3)  # Mean should increase
-    variance_before = vma.tracked_value()
+    variance_before = vma.tracked_value().item()
     assert vma.apply(
-        spike=spike_3, spike_moving_average=sma_value) > variance_before
+        spike=spike_3, spike_moving_average=sma_value).item() > variance_before


### PR DESCRIPTION
Changes:
1. The previous abstractions we added for `TemporalFilter` `SpikeMovingAverage` and `VarianceMovingAverage` are all for floats. In order to apply these efficiently for all neurons / synapses in a layer at once, we need to operate on matrices rather than float values (making sure to handle both batch and feature dims). 
2. Custom implementation of snnTorch LIF to encapsulate the logic of tracking moving averages for spike and variance for a LIF layer. The point being that we don't want to have this logic inside the network implementation, but instead it can be plumbed down into a specific LIF impl.
3. Hinting at units from Zenke paper. I am using one "unit" == 1sec. So 600 seconds is 6 * 10^5. We should confirm we don't want to instead make one "unit" == 1ms. @mstormbull FYA