### PR TITLE
[fix]: fixes to temporal filters from erratum

### DIFF
--- a/model/src/model.py
+++ b/model/src/model.py
@@ -11,22 +11,22 @@ import wandb
 from datasets.src.zenke_2a.constants import TEST_DATA_PATH, TRAIN_DATA_PATH
 from datasets.src.zenke_2a.datagen import generate_sequential_dataset
 from datasets.src.zenke_2a.dataset import SequentialDataset
-from model.src.util import MovingAverageLIF, SpikeMovingAverage, TemporalFilter, VarianceMovingAverage
+from model.src.util import MovingAverageLIF, SpikeMovingAverage, DoubleExponentialFilter, VarianceMovingAverage
 
 # Zenke's paper uses a theta_rest of -50mV
 THETA_REST = 0
 
-# Zenke's paper uses a lambda of 1
-LAMBDA_HEBBIAN = 1
+# Zenke's paper uses a lambda of 1e-4 (fixed in erratum)
+LAMBDA_HEBBIAN = 1e-4
 
 # Zenke's paper uses a beta of -1mV
 ZENKE_BETA = 1
 
-# Zenke's paper uses a xi of 1e-3
-XI = 1e-3
+# Zenke's paper uses a xi of 1e-7 (fixed in erratum)
+XI = 1e-7
 
-# Zenke's paper uses a delta of 1e-5
-DELTA = 1e-5
+# Zenke's paper uses a delta of 1e-3 (fixed in erratum)
+DELTA = 1e-3
 
 # Zenke's paper uses tau_rise and tau_fall of these values in units of ms
 TAU_RISE_ALPHA = 2
@@ -112,11 +112,11 @@ class Layer(nn.Module):
         self.prev_layer: Optional[Layer] = None
         self.next_layer: Optional[Layer] = None
 
-        self.alpha_filter_first_term = TemporalFilter(
+        self.alpha_filter_first_term = DoubleExponentialFilter(
             tau_rise=TAU_RISE_ALPHA, tau_fall=TAU_FALL_ALPHA)
-        self.epsilon_filter_first_term = TemporalFilter(
+        self.epsilon_filter_first_term = DoubleExponentialFilter(
             tau_rise=TAU_RISE_EPSILON, tau_fall=TAU_FALL_EPSILON)
-        self.alpha_filter_second_term = TemporalFilter(
+        self.alpha_filter_second_term = DoubleExponentialFilter(
             tau_rise=TAU_RISE_ALPHA, tau_fall=TAU_FALL_ALPHA)
 
         self.forward_counter = 0

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -96,12 +96,12 @@ class DoubleExponentialFilter:
             self.fall = torch.zeros_like(value)
 
         # Apply the exponential decay to the rise state and add the error
-        # NOTE: This was corrected in the erratum. Value scaled by `tau_rise`.
-        decay_factor = math.exp(-dt / self.tau_rise)
-        self.rise = self.rise * decay_factor + (1 - decay_factor) * self.tau_rise * value
+        decay_factor_rise = math.exp(-dt / self.tau_rise)
+        self.rise = self.rise * decay_factor_rise + value
 
         # Apply the exponential decay to the fall state and add the rise state
-        self.fall = self.fall * math.exp(-dt / self.tau_fall) + self.rise
+        decay_factor_fall = math.exp(-dt / self.tau_fall)
+        self.fall = self.fall * decay_factor_fall + (1 - decay_factor_fall) * self.rise
 
         return self.fall
 
@@ -205,7 +205,7 @@ class InhibitoryPlasticityTrace:
             self.trace = torch.zeros_like(spike)
 
         decay_factor = math.exp(-dt / self.tau_stdp)
-        self.trace = self.trace * decay_factor + (1 - decay_factor) * self.tau_stdp * spike
+        self.trace = self.trace * decay_factor + spike
 
         return self.trace
 

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -97,7 +97,8 @@ class DoubleExponentialFilter:
 
         # Apply the exponential decay to the rise state and add the error
         # NOTE: This was corrected in the erratum. Value scaled by `tau_rise`.
-        self.rise = self.rise * math.exp(-dt / self.tau_rise) + self.tau_rise * value
+        decay_factor = math.exp(-dt / self.tau_rise)
+        self.rise = self.rise * decay_factor + (1 - decay_factor) * self.tau_rise * value
 
         # Apply the exponential decay to the fall state and add the rise state
         self.fall = self.fall * math.exp(-dt / self.tau_fall) + self.rise
@@ -136,7 +137,8 @@ class SpikeMovingAverage:
             self.mean = torch.zeros_like(spike)
 
         # Apply the exponential decay to the mean state and add the new spike value
-        self.mean = self.mean * math.exp(-dt / self.tau_mean) + spike
+        decay_factor = math.exp(-dt / self.tau_mean)
+        self.mean = self.mean * decay_factor + (1 - decay_factor) * spike
 
         return self.mean
 
@@ -172,8 +174,9 @@ class VarianceMovingAverage:
             self.variance = torch.zeros_like(spike)
 
         # Apply the exponential decay to the variance state and add the squared deviation
-        self.variance = self.variance * math.exp(-dt / self.tau_var) + \
-            (spike - spike_moving_average) ** 2
+        decay_factor = math.exp(-dt / self.tau_var)
+        self.variance = self.variance * decay_factor + \
+            (1 - decay_factor) * (spike - spike_moving_average) ** 2
 
         return self.variance
 
@@ -201,7 +204,8 @@ class InhibitoryPlasticityTrace:
             # Initialize trace based on the first spike received
             self.trace = torch.zeros_like(spike)
 
-        self.trace = self.trace * math.exp(-dt / self.tau_stdp) + self.tau_stdp * spike
+        decay_factor = math.exp(-dt / self.tau_stdp)
+        self.trace = self.trace * decay_factor + (1 - decay_factor) * self.tau_stdp * spike
 
         return self.trace
 

--- a/model/tests/test_util.py
+++ b/model/tests/test_util.py
@@ -12,24 +12,24 @@ def test_temporal_filter() -> None:
 
     # Apply a single error with a small dt should result in small change
     assert tf.apply(value=torch.Tensor([1]), dt=1).item(
-    ) == pytest.approx(1.7357588823428847)
+    ) == pytest.approx(1.097208857536316)
 
     # Apply a zero error should result in decay of the state
     assert tf.apply(value=torch.Tensor([0]), dt=1).item(
-    ) == pytest.approx(1.1417647320527227)
+    ) == pytest.approx(0.7217329740524292)
 
 
 def test_spike_moving_average() -> None:
     sma = SpikeMovingAverage(batch_size=1, tau_mean=1, data_size=1)
 
     # Apply a single spike
-    assert sma.apply(spike=torch.Tensor([1]), dt=1).item() == 1.0
+    assert sma.apply(spike=torch.Tensor([1]), dt=1).item() == 0.6321205496788025
 
     # Apply another spike, the average should increase
-    assert sma.apply(spike=torch.Tensor([2]), dt=1).item() == 2.0
+    assert sma.apply(spike=torch.Tensor([2]), dt=1).item() == 1.496785283088684
 
     # After some time with no spikes, the average should decay
-    assert sma.apply(spike=torch.Tensor([0]), dt=1).item() == 0.0
+    assert sma.apply(spike=torch.Tensor([0]), dt=1).item() == 0.5506365299224854
 
 
 def test_variance_moving_average() -> None:
@@ -47,7 +47,7 @@ def test_variance_moving_average() -> None:
     assert sma.tracked_value().item() > 1
 
     sma_value = sma.apply(spike=spike, dt=1)
-    expected_variance = 0.3508073062162211
+    expected_variance = 0.38893842697143555
     assert vma.apply(
         spike=spike, spike_moving_average=sma_value, dt=1).item() == pytest.approx(expected_variance)
 
@@ -69,10 +69,10 @@ def test_inhibitory_plasticity_trace() -> None:
     ipt = InhibitoryPlasticityTrace()
 
     # Apply a single spike
-    assert ipt.apply(spike=torch.Tensor([1]), dt=1).item() == 1.0
+    assert ipt.apply(spike=torch.Tensor([1]), dt=1).item() == 1
 
     # Apply another spike, the trace should increase above 2
-    assert ipt.apply(spike=torch.Tensor([2]), dt=1).item() > 2.0
+    assert ipt.apply(spike=torch.Tensor([2]), dt=1).item() == 2.9512295722961426
 
     # After much time with no spikes, the trace should decay
-    assert ipt.apply(spike=torch.Tensor([0]), dt=20).item() < 2.0
+    assert ipt.apply(spike=torch.Tensor([0]), dt=20).item() == 1.0856966972351074

--- a/model/tests/test_util.py
+++ b/model/tests/test_util.py
@@ -1,11 +1,11 @@
 import pytest
 import torch
 
-from model.src.util import InhibitoryPlasticityTrace, SpikeMovingAverage, TemporalFilter, VarianceMovingAverage
+from model.src.util import InhibitoryPlasticityTrace, SpikeMovingAverage, DoubleExponentialFilter, VarianceMovingAverage
 
 
 def test_temporal_filter() -> None:
-    tf = TemporalFilter(tau_rise=1, tau_fall=1)
+    tf = DoubleExponentialFilter(tau_rise=1, tau_fall=1)
 
     # Initial apply since temporal filter is second order
     tf.apply(value=torch.Tensor([1]), dt=1)


### PR DESCRIPTION
Fixing various things inspired by the erratum:
1. Fix to [base learning rule](https://github.com/fmi-basel/latent-predictive-learning/blob/main/erratum/erratum.md#implementation-of-transmitter-triggered-plasticity-issue-2)
2. Fix to [double exponential filter](https://github.com/fmi-basel/latent-predictive-learning/blob/main/erratum/erratum.md#implementation-of-double-exponential-filtering-for-synaptic-traces-issue-3)
3. Fix to [constants](https://github.com/fmi-basel/latent-predictive-learning/blob/main/erratum/erratum.md#erroneous-sigma2-trace-normalization-issue-4)

Wrapped with this change is:
1. A rename of the `TemporalFilter` to `DoubleExponentialFilter`, as there are now many temporal filters so a bad name.
2. A conversion of the euler discretization to exponential form (more accurate) 