### PR TITLE
[feat]: support recurrent and backwards connections

### DIFF
--- a/model/src/model.py
+++ b/model/src/model.py
@@ -38,7 +38,7 @@ ENCODE_SPIKE_TRAINS = True
 PERCENTAGE_INHIBITORY = 50
 
 
-def inhibitory_mask_vec(length, percentage_ones) -> torch.Tensor:
+def inhibitory_mask_vec(length: int, percentage_ones: int) -> torch.Tensor:
     num_ones = int(length * (percentage_ones / 100))
     vector = torch.zeros(length)
     indices = torch.randperm(length)[:num_ones]
@@ -149,7 +149,9 @@ class Layer(nn.Module):
         if data is not None:
             forward_current = self.forward_weights(data)
         else:
-            forward_current = self.forward_weights(self.prev_layer.lif.spike_moving_average.spike_rec[-1].detach())
+            assert self.prev_layer is not None
+            forward_current = self.forward_weights(
+                self.prev_layer.lif.spike_moving_average.spike_rec[-1].detach())
 
         # if self.next_layer is not None:
         #     backward_current = self.backward_weights(self.next_layer.lif.spike_moving_average.spike_rec[-1].detach())
@@ -243,7 +245,8 @@ class Layer(nn.Module):
         wandb.log(
             {"dw_dt": dw_dt[0][0]}, step=self.forward_counter)
 
-    def train_forward_excitatory_from_layer(self, spike: torch.Tensor, filter_group: SynapseFilterGroup, from_layer: Optional[Self], data: Optional[torch.Tensor]) -> None:
+    def train_forward_excitatory_from_layer(self, spike: torch.Tensor, filter_group: SynapseFilterGroup,
+                                            from_layer: Optional[Self], data: Optional[torch.Tensor]) -> None:
         """
         The LPL excitatory learning rule is implemented here. It is defined as dw_ji/dt,
         for which we optimize the computation with matrices.

--- a/model/src/model.py
+++ b/model/src/model.py
@@ -10,7 +10,7 @@ import wandb
 
 from datasets.src.zenke_2a.constants import TEST_DATA_PATH, TRAIN_DATA_PATH
 from datasets.src.zenke_2a.dataset import SequentialDataset
-from model.src.util import MovingAverageLIF, DoubleExponentialFilter, SynapseFilterGroup
+from model.src.util import MovingAverageLIF, SynapseFilterGroup
 
 # Zenke's paper uses a theta_rest of -50mV
 THETA_REST = 0
@@ -239,7 +239,7 @@ class Layer(nn.Module):
 
     def train_forward_excitatory_from_layer(self, spike: torch.Tensor, filter_group: SynapseFilterGroup, from_layer: Optional[Self], data: Optional[torch.Tensor]) -> None:
         """
-        The LPL learning rule is implemented here. It is defined as dw_ji/dt,
+        The LPL excitatory learning rule is implemented here. It is defined as dw_ji/dt,
         for which we optimize the computation with matrices.
 
         This learning rule is broken up into three terms:
@@ -257,9 +257,6 @@ class Layer(nn.Module):
         divided by the batch size to form the final dw_ij/dt matrix. We then
         mask this to filter out the inhibitory weights and apply this to the
         excitatory weights.
-
-        TODOPRE: need to add to desc
-        TODOPRE: need to add mask
         """
 
         from_layer_size = from_layer.layer_settings.size if from_layer is not None else self.layer_settings.data_size

--- a/model/src/model.py
+++ b/model/src/model.py
@@ -11,22 +11,22 @@ import wandb
 from datasets.src.zenke_2a.constants import TEST_DATA_PATH, TRAIN_DATA_PATH
 from datasets.src.zenke_2a.datagen import generate_sequential_dataset
 from datasets.src.zenke_2a.dataset import SequentialDataset
-from model.src.util import MovingAverageLIF, SpikeMovingAverage, TemporalFilter, VarianceMovingAverage
+from model.src.util import MovingAverageLIF, SpikeMovingAverage, DoubleExponentialFilter, VarianceMovingAverage
 
 # Zenke's paper uses a theta_rest of -50mV
 THETA_REST = 0
 
-# Zenke's paper uses a lambda of 1
-LAMBDA_HEBBIAN = 1
+# Zenke's paper uses a lambda of 1e-4 (fixed in erratum)
+LAMBDA_HEBBIAN = 1e-4
 
 # Zenke's paper uses a beta of -1mV
 ZENKE_BETA = 1
 
-# Zenke's paper uses a xi of 1e-3
-XI = 1e-3
+# Zenke's paper uses a xi of 1e-7 (fixed in erratum)
+XI = 1e-7
 
-# Zenke's paper uses a delta of 1e-5
-DELTA = 1e-5
+# Zenke's paper uses a delta of 1e-3 (fixed in erratum)
+DELTA = 1e-3
 
 # Zenke's paper uses tau_rise and tau_fall of these values in units of ms
 TAU_RISE_ALPHA = 2
@@ -112,11 +112,11 @@ class Layer(nn.Module):
         self.prev_layer: Optional[Layer] = None
         self.next_layer: Optional[Layer] = None
 
-        self.alpha_filter_first_term = TemporalFilter(
+        self.alpha_filter_first_term = DoubleExponentialFilter(
             tau_rise=TAU_RISE_ALPHA, tau_fall=TAU_FALL_ALPHA)
-        self.epsilon_filter_first_term = TemporalFilter(
+        self.epsilon_filter_first_term = DoubleExponentialFilter(
             tau_rise=TAU_RISE_EPSILON, tau_fall=TAU_FALL_EPSILON)
-        self.alpha_filter_second_term = TemporalFilter(
+        self.alpha_filter_second_term = DoubleExponentialFilter(
             tau_rise=TAU_RISE_ALPHA, tau_fall=TAU_FALL_ALPHA)
 
         self.forward_counter = 0

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -96,12 +96,12 @@ class DoubleExponentialFilter:
             self.fall = torch.zeros_like(value)
 
         # Apply the exponential decay to the rise state and add the error
-        # NOTE: This was corrected in the erratum. Value scaled by `tau_rise`.
-        decay_factor = math.exp(-dt / self.tau_rise)
-        self.rise = self.rise * decay_factor + (1 - decay_factor) * self.tau_rise * value
+        decay_factor_rise = math.exp(-dt / self.tau_rise)
+        self.rise = self.rise * decay_factor_rise + value
 
         # Apply the exponential decay to the fall state and add the rise state
-        self.fall = self.fall * math.exp(-dt / self.tau_fall) + self.rise
+        decay_factor_fall = math.exp(-dt / self.tau_fall)
+        self.fall = self.fall * decay_factor_fall + (1 - decay_factor_fall) * self.rise
 
         return self.fall
 
@@ -205,7 +205,7 @@ class InhibitoryPlasticityTrace:
             self.trace = torch.zeros_like(spike)
 
         decay_factor = math.exp(-dt / self.tau_stdp)
-        self.trace = self.trace * decay_factor + (1 - decay_factor) * self.tau_stdp * spike
+        self.trace = self.trace * decay_factor + spike
 
         return self.trace
 

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -16,6 +16,12 @@ TAU_STDP = 20
 # Zenke's paper uses a .1ms time step
 DT = .1
 
+# Zenke's paper uses tau_rise and tau_fall of these values in units of ms
+TAU_RISE_ALPHA = 2
+TAU_FALL_ALPHA = 10
+TAU_RISE_EPSILON = 5
+TAU_FALL_EPSILON = 20
+
 MAX_RETAINED_SPIKES = int(20 / DT)
 
 
@@ -104,6 +110,14 @@ class DoubleExponentialFilter:
         self.fall = self.fall * decay_factor_fall + (1 - decay_factor_fall) * self.rise
 
         return self.fall
+
+
+class SynapseFilterGroup:
+
+    def __init__(self):
+        self.first_term_alpha = DoubleExponentialFilter(TAU_RISE_ALPHA, TAU_FALL_ALPHA)
+        self.first_term_epsilon = DoubleExponentialFilter(TAU_RISE_EPSILON, TAU_FALL_EPSILON)
+        self.second_term_alpha = DoubleExponentialFilter(TAU_RISE_ALPHA, TAU_FALL_ALPHA)
 
 
 class SpikeMovingAverage:

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -114,7 +114,7 @@ class DoubleExponentialFilter:
 
 class SynapseFilterGroup:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.first_term_alpha = DoubleExponentialFilter(TAU_RISE_ALPHA, TAU_FALL_ALPHA)
         self.first_term_epsilon = DoubleExponentialFilter(TAU_RISE_EPSILON, TAU_FALL_EPSILON)
         self.second_term_alpha = DoubleExponentialFilter(TAU_RISE_ALPHA, TAU_FALL_ALPHA)
@@ -192,6 +192,7 @@ class VarianceMovingAverage:
         self.variance = self.variance * decay_factor + \
             (1 - decay_factor) * (spike - spike_moving_average) ** 2
 
+        assert self.variance is not None
         return self.variance
 
     def tracked_value(self) -> torch.Tensor:
@@ -224,7 +225,7 @@ class InhibitoryPlasticityTrace:
         return self.trace
 
     def tracked_value(self) -> torch.Tensor:
-        if self.tau_stdp is None:
+        if self.trace is None:
             raise ValueError("No data has been received yet")
 
-        return self.tau_stdp
+        return self.trace

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -97,7 +97,8 @@ class DoubleExponentialFilter:
 
         # Apply the exponential decay to the rise state and add the error
         # NOTE: This was corrected in the erratum. Value scaled by `tau_rise`.
-        self.rise = self.rise * math.exp(-dt / self.tau_rise) + self.tau_rise * value
+        decay_factor = math.exp(-dt / self.tau_rise)
+        self.rise = self.rise * decay_factor + (1 - decay_factor) * self.tau_rise * value
 
         # Apply the exponential decay to the fall state and add the rise state
         self.fall = self.fall * math.exp(-dt / self.tau_fall) + self.rise
@@ -136,7 +137,8 @@ class SpikeMovingAverage:
             self.mean = torch.zeros_like(spike)
 
         # Apply the exponential decay to the mean state and add the new spike value
-        self.mean = self.mean * math.exp(-dt / self.tau_mean) + spike
+        decay_factor = math.exp(-dt / self.tau_mean)
+        self.mean = self.mean * decay_factor + (1 - decay_factor) * spike
 
         return self.mean
 
@@ -172,8 +174,9 @@ class VarianceMovingAverage:
             self.variance = torch.zeros_like(spike)
 
         # Apply the exponential decay to the variance state and add the squared deviation
-        self.variance = self.variance * math.exp(-dt / self.tau_var) + \
-            (spike - spike_moving_average) ** 2
+        decay_factor = math.exp(-dt / self.tau_var)
+        self.variance = self.variance * decay_factor + \
+            (1 - decay_factor) * (spike - spike_moving_average) ** 2
 
         return self.variance
 
@@ -201,7 +204,8 @@ class InhibitoryPlasticityTrace:
             # Initialize trace based on the first spike received
             self.trace = torch.zeros_like(spike)
 
-        self.trace = self.trace * math.exp(-dt / self.tau_stdp) + self.tau_stdp * spike
+        decay_factor = math.exp(-dt / self.tau_stdp)
+        self.trace = self.trace * decay_factor + (1 - decay_factor) * self.tau_stdp * spike
 
         return self.trace
 

--- a/model/tests/test_util.py
+++ b/model/tests/test_util.py
@@ -12,24 +12,24 @@ def test_temporal_filter() -> None:
 
     # Apply a single error with a small dt should result in small change
     assert tf.apply(value=torch.Tensor([1]), dt=1).item(
-    ) == pytest.approx(1.7357588823428847)
+    ) == pytest.approx(1.097208857536316)
 
     # Apply a zero error should result in decay of the state
     assert tf.apply(value=torch.Tensor([0]), dt=1).item(
-    ) == pytest.approx(1.1417647320527227)
+    ) == pytest.approx(0.7217329740524292)
 
 
 def test_spike_moving_average() -> None:
     sma = SpikeMovingAverage(batch_size=1, tau_mean=1, data_size=1)
 
     # Apply a single spike
-    assert sma.apply(spike=torch.Tensor([1]), dt=1).item() == 1.0
+    assert sma.apply(spike=torch.Tensor([1]), dt=1).item() == 0.6321205496788025
 
     # Apply another spike, the average should increase
-    assert sma.apply(spike=torch.Tensor([2]), dt=1).item() == 2.0
+    assert sma.apply(spike=torch.Tensor([2]), dt=1).item() == 1.496785283088684
 
     # After some time with no spikes, the average should decay
-    assert sma.apply(spike=torch.Tensor([0]), dt=1).item() == 0.0
+    assert sma.apply(spike=torch.Tensor([0]), dt=1).item() == 0.5506365299224854
 
 
 def test_variance_moving_average() -> None:
@@ -47,7 +47,7 @@ def test_variance_moving_average() -> None:
     assert sma.tracked_value().item() > 1
 
     sma_value = sma.apply(spike=spike, dt=1)
-    expected_variance = 0.3508073062162211
+    expected_variance = 0.38893842697143555
     assert vma.apply(
         spike=spike, spike_moving_average=sma_value, dt=1).item() == pytest.approx(expected_variance)
 
@@ -69,10 +69,10 @@ def test_inhibitory_plasticity_trace() -> None:
     ipt = InhibitoryPlasticityTrace()
 
     # Apply a single spike
-    assert ipt.apply(spike=torch.Tensor([1]), dt=1).item() == 1.0
+    assert ipt.apply(spike=torch.Tensor([1]), dt=1).item() == 1
 
     # Apply another spike, the trace should increase above 2
-    assert ipt.apply(spike=torch.Tensor([2]), dt=1).item() > 2.0
+    assert ipt.apply(spike=torch.Tensor([2]), dt=1).item() == 2.9512295722961426
 
     # After much time with no spikes, the trace should decay
-    assert ipt.apply(spike=torch.Tensor([0]), dt=20).item() < 2.0
+    assert ipt.apply(spike=torch.Tensor([0]), dt=20).item() == 1.0856966972351074

--- a/model/tests/test_util.py
+++ b/model/tests/test_util.py
@@ -1,11 +1,11 @@
 import pytest
 import torch
 
-from model.src.util import InhibitoryPlasticityTrace, SpikeMovingAverage, TemporalFilter, VarianceMovingAverage
+from model.src.util import InhibitoryPlasticityTrace, SpikeMovingAverage, DoubleExponentialFilter, VarianceMovingAverage
 
 
 def test_temporal_filter() -> None:
-    tf = TemporalFilter(tau_rise=1, tau_fall=1)
+    tf = DoubleExponentialFilter(tau_rise=1, tau_fall=1)
 
     # Initial apply since temporal filter is second order
     tf.apply(value=torch.Tensor([1]), dt=1)


### PR DESCRIPTION
Changes:
1. Support recurrent and backwards connections
2. Split out excitatory weight updates from inhibitory, so it is easy to add in the inhibitory rule in a later PR.
3. Add an inhibitory mask for each layer to specify which neurons are the inhibitory neurons within a given layer. We apply this mask whenever performing weight updates so that the excitatory rule only updates excitatory synapses (Dale's Law).