### PR TITLE
[feat]: change LIF to issue spike at same timestep

### DIFF
--- a/model/src/lif.py
+++ b/model/src/lif.py
@@ -12,6 +12,17 @@ class LIF(nn.Module):
 
         NOTE: The membrane potential is not resting at a negative value, as it
         is in Zenke's work. This implementation may need to change.
+
+        NOTE: The ordering of the following operations within a timestep is
+        important. So we need to pick the correct ordering. The current
+        implementation follows Zenke's work, HOWEVER, the membrane potential
+        used in the learning rule is separate from this implementation, and may
+        either use the `mem` or `prereset_mem`.
+
+        Order of operations:
+        1. Update membrane potential
+        2. Spike if membrane potential exceeds threshold
+        3. Reset the membrane potential if spiked
         """
         super(LIF, self).__init__()
         # Initialize decay rate beta and threshold

--- a/model/src/lif.py
+++ b/model/src/lif.py
@@ -38,6 +38,7 @@ class LIF(nn.Module):
             self.prereset_mem = torch.zeros_like(current)
 
         # Update membrane potential: decay and add current
+        assert self.mem is not None
         self.mem = self.beta * self.mem + current
         self.prereset_mem = self.mem.clone()
 

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -1,6 +1,6 @@
 import math
 from collections import deque
-from typing import Any, Deque, Optional, Tuple
+from typing import Deque, Optional
 
 import torch
 
@@ -45,6 +45,9 @@ class MovingAverageLIF():
         if self.neuron_layer.prereset_mem is None:
             raise ValueError("No data has been received yet")
 
+        # NOTE: The membrane potential returned here is used in the learning
+        # rule. Currently, we are not returning what Zenke's paper uses (they
+        # use `neuron_layer.mem`).
         return self.neuron_layer.prereset_mem
 
     def tracked_spike_moving_average(self) -> torch.Tensor:

--- a/model/src/util.py
+++ b/model/src/util.py
@@ -42,10 +42,10 @@ class MovingAverageLIF():
         return (spike)
 
     def mem(self) -> torch.Tensor:
-        if self.neuron_layer.mem is None:
+        if self.neuron_layer.prereset_mem is None:
             raise ValueError("No data has been received yet")
 
-        return self.neuron_layer.mem
+        return self.neuron_layer.prereset_mem
 
     def tracked_spike_moving_average(self) -> torch.Tensor:
         return self.spike_moving_average.tracked_value()

--- a/model/tests/test_lif.py
+++ b/model/tests/test_lif.py
@@ -17,8 +17,8 @@ def test_membrane_behaves_for_lif_spikes_for_membrane_above_0() -> None:
     assert (lif.prereset_mem == 2).all()  # type: ignore
 
     # make sure no spike at second based on previous current
-    prev_lif_mem = lif.mem.clone()
-    prev_lif_prereset_mem = lif.prereset_mem.clone()
+    prev_lif_mem = lif.mem.clone()  # type: ignore
+    prev_lif_prereset_mem = lif.prereset_mem.clone()  # type: ignore
     input = torch.tensor([[0, 0, 0], [0, 0, 0]])
     spk = lif(input)
     assert (spk == 0).all()  # type: ignore


### PR DESCRIPTION
Changes:
1. Change LIF to issue spike at same timestep
2. Record prereset membrane potential. This change is made such that the learning rule and logging does not observe a < 1 membrane potential for a spike.
3. Use the prereset membrane potential in the learning rule. This is not what Zenke did and I noted that in case we need to change later.