### PR TITLE
[feat]: inhibitory learning rule

### DIFF
--- a/model/tests/test_util.py
+++ b/model/tests/test_util.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import pytest
 import torch
 
@@ -66,13 +67,14 @@ def test_variance_moving_average() -> None:
 
 
 def test_inhibitory_plasticity_trace() -> None:
-    ipt = InhibitoryPlasticityTrace()
+    trace_shape: Tuple[int, int] = (1, 1)
+    ipt = InhibitoryPlasticityTrace(trace_shape)
 
     # Apply a single spike
-    assert ipt.apply(spike=torch.Tensor([1]), dt=1).item() == 1
+    assert ipt.apply(spike=torch.Tensor([[1]]), dt=1).item() == 1
 
     # Apply another spike, the trace should increase above 2
-    assert ipt.apply(spike=torch.Tensor([2]), dt=1).item() == 2.9512295722961426
+    assert ipt.apply(spike=torch.Tensor([[2]]), dt=1).item() == 2.9512295722961426
 
     # After much time with no spikes, the trace should decay
-    assert ipt.apply(spike=torch.Tensor([0]), dt=20).item() == 1.0856966972351074
+    assert ipt.apply(spike=torch.Tensor([[0]]), dt=20).item() == 1.0856966972351074


### PR DESCRIPTION
Changes:
1. Implemented the inhibitory learning rule
2. As a side effect of implementing the inhibitory learning rule, we have to account for inhibition to the layer neurons each time a synapse contributes to the membrane potential. This is handled by masking the weights for excitatory vs inhibitory and then performing a matmul to get the presynaptic current for one component (forward, or recurrent -- no backwards yet). This code change affects the [forward method of Layer](https://github.com/and-rewsmith/LPL-SNN/pull/31/files#diff-b6126ef485b720d64c52eed339593258f4dc2cbaeade80a028d5346c8ffe294cR154).
3. Uncommented the backwards connections handling and removed all related TODOs for that. So now the backwards connections are implemented, however they are not being used due to our current model only running one layer. That is why it is safe to uncomment them.