### PR TITLE
[feat]: logging for pointcloud benchmark

### DIFF
--- a/benchmarks/src/pointcloud.py
+++ b/benchmarks/src/pointcloud.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
 
     settings = Settings(
         layer_sizes=[2],
-        num_steps=100,
+        num_steps=5000,
         data_size=2,
         batch_size=1,
         learning_rate=0.01,
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 
     wandb.init(
         # set the wandb project where this run will be logged
-        project="LPL-SNN",
+        project="LPL-SNN-2",
 
         # track hyperparameters and run metadata
         config={
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         train_sequential_dataset, batch_size=settings.batch_size, shuffle=False)
 
     test_dataframe = pd.read_csv(TEST_DATA_PATH)
-    test_sequential_dataset = SequentialDataset(test_dataframe)
+    test_sequential_dataset = SequentialDataset(test_dataframe, num_timesteps=settings.num_steps)
     test_data_loader = DataLoader(
         test_sequential_dataset, batch_size=10, shuffle=False)
 

--- a/datasets/src/zenke_2a/datagen.py
+++ b/datasets/src/zenke_2a/datagen.py
@@ -5,8 +5,8 @@ from datasets.src.zenke_2a.constants import TEST_DATA_PATH, TRAIN_DATA_PATH
 
 
 # TODO: can use guassian mixture model to generate data
-def generate_sequential_dataset(num_samples: int = 100, num_datapoints: int = 100, num_clusters: int = 2,
-                                cluster_switch_prob: float = 0.01, cluster_spread: float = 0.5) -> pd.DataFrame:
+def generate_sequential_dataset(num_samples: int = 100, num_datapoints: int = 5000, num_clusters: int = 2,
+                                cluster_switch_prob: float = 0.05, cluster_spread: float = 0.5) -> pd.DataFrame:
     """
     Generates a sequential dataset with rare abrupt switches between clusters, organized into batches,
     with a defined number of samples per batch.

--- a/model/src/layer.py
+++ b/model/src/layer.py
@@ -188,34 +188,39 @@ class Layer(nn.Module):
             f"forward weights shape: {self.forward_weights.weight.shape}")
         logging.debug(f"forward weights: {self.forward_weights.weight}")
 
-        wandb.log({"mem": mem[0][0]}, step=self.forward_counter)
-        wandb.log({"spike": spike[0][0]}, step=self.forward_counter)
+        def reduce_feature_dims_with_mask(tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+            return tensor[mask.unsqueeze(0).expand(self.layer_settings.batch_size, -1).bool()]
 
-        wandb.log({"inhibitory_trace": self.inhibitory_trace.tracked_value()}, step=self.forward_counter)
+        # NOTE: if we want to log just one data point index the batch dim into these tensors
+        excitatory_mem = reduce_feature_dims_with_mask(mem, self.excitatory_mask_vec)
+        inhibitory_mem = reduce_feature_dims_with_mask(mem, self.inhibitory_mask_vec)
+        excitatory_spike = reduce_feature_dims_with_mask(spike, self.excitatory_mask_vec)
+        inhibitory_spike = reduce_feature_dims_with_mask(spike, self.inhibitory_mask_vec)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_exc_mem": excitatory_mem.mean()}, step=self.forward_counter)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_inh_mem": inhibitory_mem.mean()}, step=self.forward_counter)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_exc_spike": excitatory_spike.mean()}, step=self.forward_counter)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_inh_spike": inhibitory_spike.mean()}, step=self.forward_counter)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_data_point_0": self.data[0][0]}, step=self.forward_counter)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_data_point_1": self.data[0][1]}, step=self.forward_counter)
 
-        wandb.log(
-            {"first_term_no_filter": excitatory_equation.first_term.no_filter[0][0][0]}, step=self.forward_counter)
-        wandb.log(
-            {"first_term_epsilon": excitatory_equation.first_term.epsilon_filter[0][0][0]},
-            step=self.forward_counter)
+        # TODO: The below metrics are specific to the dataset so will eventually need to be removed
 
-        wandb.log(
-            {"second_term_prediction_error": excitatory_equation.second_term.prediction_error[0][0]},
-            step=self.forward_counter)
-        wandb.log(
-            {"second_term_deviation_scale": excitatory_equation.second_term.deviation_scale[0][0]},
-            step=self.forward_counter)
-        wandb.log(
-            {"second_term_deviation": excitatory_equation.second_term.deviation[0][0]}, step=self.forward_counter)
-        wandb.log(
-            {"second_term_no_filter": excitatory_equation.second_term.no_filter[0][0]}, step=self.forward_counter)
+        # Log for a layer the weight from the first datapoint to the excitatory
+        # neuron. The key here is that we need to know what the excitatory
+        # neuron is in order to figure out how to index into the forward
+        # weights.
+        excitatory_masked_weight = self.excitatory_mask_vec.unsqueeze(1).expand(-1, self.layer_settings.data_size) * \
+            self.forward_weights.weight
+        # Identify rows that are not all zeros
+        non_zero_rows = excitatory_masked_weight.any(dim=1)
+        # Filter out rows that are all zeros
+        excitatory_masked_weight = excitatory_masked_weight[non_zero_rows]
+        assert excitatory_masked_weight.shape == (1, self.layer_settings.data_size)
 
-        wandb.log(
-            {"first_term": excitatory_equation.first_term.alpha_filter[0][0][0]}, step=self.forward_counter)
-        wandb.log({"second_term": excitatory_equation.second_term.alpha_filter[0][0][0]},
+        wandb.log({f"layer_{self.layer_settings.layer_id}_exc_weight_0": excitatory_masked_weight[0][0]},
                   step=self.forward_counter)
         wandb.log(
-            {"dw_dt": dw_dt[0][0]}, step=self.forward_counter)
+            {f"layer_{self.layer_settings.layer_id}_exc_weight_1": excitatory_masked_weight[0][1]}, step=self.forward_counter)
 
     def train_excitatory_from_layer(self, synaptic_update_type: SynapticUpdateType, spike: torch.Tensor,
                                     filter_group: ExcitatorySynapseFilterGroup, from_layer: Optional[Self],
@@ -347,6 +352,9 @@ class Layer(nn.Module):
                     second_term=second_term,
                 )
 
+                # TODO: Remove this when we decouple the logging for the
+                # pointcloud benchmark from the model code
+                self.data = data
                 self.__log_equation_context(synaptic_weight_equation, dw_dt, spike, self.lif.mem())
 
     def train_inhibitory_from_layer(self, synaptic_update_type: SynapticUpdateType, spike: torch.Tensor,

--- a/model/src/layer.py
+++ b/model/src/layer.py
@@ -207,23 +207,24 @@ class Layer(nn.Module):
 
         # TODO: The below metrics are specific to the dataset so will eventually need to be removed
 
-        # Log for a layer the weight from the first datapoint to the excitatory
-        # neuron. The key here is that we need to know what the excitatory
-        # neuron is in order to figure out how to index into the forward
-        # weights.
-        excitatory_masked_weight = self.excitatory_mask_vec.unsqueeze(1).expand(-1, self.layer_settings.data_size) * \
-            self.forward_weights.weight
-        # Identify rows that are not all zeros
-        non_zero_rows = excitatory_masked_weight.any(dim=1)
-        # Filter out rows that are all zeros
-        excitatory_masked_weight = excitatory_masked_weight[non_zero_rows]
-        assert excitatory_masked_weight.shape == (1, self.layer_settings.data_size)
+        if self.layer_settings.layer_id == 0:
+            # Log for a layer the weight from the first datapoint to the excitatory
+            # neuron. The key here is that we need to know what the excitatory
+            # neuron is in order to figure out how to index into the forward
+            # weights.
+            excitatory_masked_weight = self.excitatory_mask_vec.unsqueeze(1).expand(-1, self.layer_settings.data_size) * \
+                self.forward_weights.weight
+            # Identify rows that are not all zeros
+            non_zero_rows = excitatory_masked_weight.any(dim=1)
+            # Filter out rows that are all zeros
+            excitatory_masked_weight = excitatory_masked_weight[non_zero_rows]
+            assert excitatory_masked_weight.shape == (1, self.layer_settings.data_size)
 
-        wandb.log({f"layer_{self.layer_settings.layer_id}_exc_weight_0": excitatory_masked_weight[0][0]},
-                  step=self.forward_counter)
-        wandb.log(
-            {f"layer_{self.layer_settings.layer_id}_exc_weight_1": excitatory_masked_weight[0][1]},
-            step=self.forward_counter)
+            wandb.log({f"layer_{self.layer_settings.layer_id}_exc_weight_0": excitatory_masked_weight[0][0]},
+                      step=self.forward_counter)
+            wandb.log(
+                {f"layer_{self.layer_settings.layer_id}_exc_weight_1": excitatory_masked_weight[0][1]},
+                step=self.forward_counter)
 
     def train_excitatory_from_layer(self, synaptic_update_type: SynapticUpdateType, spike: torch.Tensor,
                                     filter_group: ExcitatorySynapseFilterGroup, from_layer: Optional[Self],

--- a/model/src/layer.py
+++ b/model/src/layer.py
@@ -198,8 +198,10 @@ class Layer(nn.Module):
         inhibitory_spike = reduce_feature_dims_with_mask(spike, self.inhibitory_mask_vec)
         wandb.log({f"layer_{self.layer_settings.layer_id}_exc_mem": excitatory_mem.mean()}, step=self.forward_counter)
         wandb.log({f"layer_{self.layer_settings.layer_id}_inh_mem": inhibitory_mem.mean()}, step=self.forward_counter)
-        wandb.log({f"layer_{self.layer_settings.layer_id}_exc_spike": excitatory_spike.mean()}, step=self.forward_counter)
-        wandb.log({f"layer_{self.layer_settings.layer_id}_inh_spike": inhibitory_spike.mean()}, step=self.forward_counter)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_exc_spike": excitatory_spike.mean()},
+                  step=self.forward_counter)
+        wandb.log({f"layer_{self.layer_settings.layer_id}_inh_spike": inhibitory_spike.mean()},
+                  step=self.forward_counter)
         wandb.log({f"layer_{self.layer_settings.layer_id}_data_point_0": self.data[0][0]}, step=self.forward_counter)
         wandb.log({f"layer_{self.layer_settings.layer_id}_data_point_1": self.data[0][1]}, step=self.forward_counter)
 
@@ -220,7 +222,8 @@ class Layer(nn.Module):
         wandb.log({f"layer_{self.layer_settings.layer_id}_exc_weight_0": excitatory_masked_weight[0][0]},
                   step=self.forward_counter)
         wandb.log(
-            {f"layer_{self.layer_settings.layer_id}_exc_weight_1": excitatory_masked_weight[0][1]}, step=self.forward_counter)
+            {f"layer_{self.layer_settings.layer_id}_exc_weight_1": excitatory_masked_weight[0][1]},
+            step=self.forward_counter)
 
     def train_excitatory_from_layer(self, synaptic_update_type: SynapticUpdateType, spike: torch.Tensor,
                                     filter_group: ExcitatorySynapseFilterGroup, from_layer: Optional[Self],

--- a/model/src/layer.py
+++ b/model/src/layer.py
@@ -212,8 +212,8 @@ class Layer(nn.Module):
             # neuron. The key here is that we need to know what the excitatory
             # neuron is in order to figure out how to index into the forward
             # weights.
-            excitatory_masked_weight = self.excitatory_mask_vec.unsqueeze(1).expand(-1, self.layer_settings.data_size) * \
-                self.forward_weights.weight
+            excitatory_masked_weight = self.excitatory_mask_vec.unsqueeze(1).expand(-1, self.layer_settings.data_size) \
+                * self.forward_weights.weight
             # Identify rows that are not all zeros
             non_zero_rows = excitatory_masked_weight.any(dim=1)
             # Filter out rows that are all zeros

--- a/model/src/network.py
+++ b/model/src/network.py
@@ -8,7 +8,7 @@ from model.src.layer import Layer
 from model.src.settings import LayerSettings, Settings
 
 
-# TODO: Impleent functionality to reset the network in between batches
+# TODO: Implement functionality to reset the network in between batches
 class Net(nn.Module):
     def __init__(self, settings: Settings) -> None:
         super().__init__()
@@ -21,9 +21,10 @@ class Net(nn.Module):
             prev_size = settings.data_size if i == 0 else settings.layer_sizes[i-1]
             next_size = settings.layer_sizes[i+1] if i < len(
                 settings.layer_sizes) - 1 else 0
-            layer_settings = LayerSettings(
-                prev_size, size, next_size,
-                settings.batch_size, settings.learning_rate, settings.data_size)
+            layer_id = i
+            layer_settings = LayerSettings(layer_id,
+                                           prev_size, size, next_size,
+                                           settings.batch_size, settings.learning_rate, settings.data_size)
             network_layer_settings.append(layer_settings)
 
         # make layers
@@ -47,8 +48,7 @@ class Net(nn.Module):
                 batch = batch.permute(1, 0, 2)
 
                 if self.settings.encode_spike_trains:
-                    # poisson encode
-                    batch = spikegen.rate(batch, time_var_input=True)
+                    batch = (batch > 0.5).float()
 
                 logging.info(
                     f"Epoch {epoch} - Batch {i} - Sample data: {batch.shape}")
@@ -61,3 +61,6 @@ class Net(nn.Module):
                             spk = layer.forward()
 
                         layer.train_synapses(spk, batch[timestep])
+
+                # TODO: remove when network is stabilized
+                raise NotImplementedError("Network is not yet stabilized for multi batch")

--- a/model/src/settings.py
+++ b/model/src/settings.py
@@ -17,8 +17,9 @@ class Settings:
 
 
 class LayerSettings:
-    def __init__(self, prev_size: int, size: int, next_size: int,
+    def __init__(self, layer_id: int, prev_size: int, size: int, next_size: int,
                  batch_size: int, learning_rate: float, data_size: int) -> None:
+        self.layer_id = layer_id
         self.prev_size = prev_size
         self.size = size
         self.next_size = next_size


### PR DESCRIPTION
I merged another PR which fixed a bug in my forward pass implementation, and also scaled the tau constants (same as Zenke but there is nuance in interpreting the units seconds vs ms -- I changed to 1 unit == 1 second).
https://github.com/and-rewsmith/LPL-SNN/pull/33

After this change I made some wandb plots around how the excitatory neuron becomes selective to the appropriate data input in the point cloud task. To remind about the point cloud task, 2 data points are passed in sequentially to the model. There are two clusters for each of these data points to fall into. The clusters are aligned with the x coordinate range for a single cluster being very narrow, whereas the y coordinate range is unrestricted. 

The two data points at each timestep represent x,y coordinates, where between timesteps the x coordinate usually stays within the same cluster (small change), whereas the y coordinate changes completely randomly with no restriction . Here is a visualization of the clustering.
![image](https://github.com/and-rewsmith/LPL-SNN/assets/19913741/2e3ed65b-54a0-4ade-9390-6ec98563ed04)


There is no output to our LPL network (1 excitatory neuron / 1 inhibitory neuron), but based on Zenke experimental results we should see the single excitatory neuron to become selective to the x coordinate over the y. coordinate. It looks like this happens, which is promising. I applied some smoothing to the layer_0_excitatory spike so it is clear that the excitatory spike trends the data_point_0 (x). But wait -- this doesn't really mean much since of course the excitatory spike will trend the data point 0 since the excitatory spike roughly would just follow the total current in an untrained network. So we need more analysis.

(Another cool thing to note, is that we got past the barrier that the excitatory neuron spiking ran away. This was due to the constant rescaling, along with the inhibitory neurons. We are not even using ALIFs, but I don't think Zenke actually did according to the erratum. 
![image](https://github.com/and-rewsmith/LPL-SNN/assets/19913741/247e47bc-dd0e-4140-9300-2fc4e880723b)



>  But wait -- this doesn't really mean much since of course the excitatory spike will trend the data point 0 since the excitatory spike roughly would just follow the total current in an untrained network. So we need more analysis.

In order to analyze this further, we can check to see if the weight for the connection between the data point 0 and the excitatory neuron remains positive, and the weight for the connection between data point 1 and the excitatory neuron decreases. Luckily, it looks like this happens too -- and the weight for data point 1 actually decays completely!
![image](https://github.com/and-rewsmith/LPL-SNN/assets/19913741/8bb16886-18e2-4fb0-acfb-d9664681da09)



My next thinking is that we need to clamp these weights from flipping sign.